### PR TITLE
Update jekylltoghost.rb to work with Jekyll 4.0.0

### DIFF
--- a/jekylltoghost.rb
+++ b/jekylltoghost.rb
@@ -24,6 +24,8 @@ module Jekyll
 			@dir  = dir
 			@name = name
 			@contents = contents
+			@relative_path = File.join(*[@dir, @name].compact)
+			@extname = File.extname(@name)
 		end
 
 		def write(dest)


### PR DESCRIPTION
I was getting `undefined method `length' for nil:NilClass (NoMethodError) from `jekyll-4.0.0/lib/jekyll/static_file.rb:148:in `cleaned_relative_path'`.

extname (dir and name) as well as relative_path were empty (and they were part of Jekyll::StaticFile intializer. Added the setters to GhostPage initializer.